### PR TITLE
refactor(cli): delegate sandbox command detection to shared script

### DIFF
--- a/packages/cli/src/config/sandboxConfig.ts
+++ b/packages/cli/src/config/sandboxConfig.ts
@@ -5,97 +5,29 @@
  */
 
 import { SandboxConfig } from '@google/gemini-cli-core';
-import commandExists from 'command-exists';
-import * as os from 'node:os';
+import { execSync } from 'node:child_process';
+import * as path from 'node:path';
 import { getPackageJson } from '../utils/package.js';
 import { Settings } from './settings.js';
 
-// This is a stripped-down version of the CliArgs interface from config.ts
-// to avoid circular dependencies.
-interface SandboxCliArgs {
-  sandbox?: boolean | string;
-  'sandbox-image'?: string;
-}
-
-const VALID_SANDBOX_COMMANDS: ReadonlyArray<SandboxConfig['command']> = [
-  'docker',
-  'podman',
-  'sandbox-exec',
-];
-
-function isSandboxCommand(value: string): value is SandboxConfig['command'] {
-  return (VALID_SANDBOX_COMMANDS as readonly string[]).includes(value);
-}
-
-function getSandboxCommand(
-  sandbox?: boolean | string,
-): SandboxConfig['command'] | '' {
-  // If the SANDBOX env var is set, we're already inside the sandbox.
-  if (process.env.SANDBOX) {
-    return '';
-  }
-
-  // note environment variable takes precedence over argument (from command line or settings)
-  const environmentConfiguredSandbox =
-    process.env.GEMINI_SANDBOX?.toLowerCase().trim() ?? '';
-  sandbox =
-    environmentConfiguredSandbox?.length > 0
-      ? environmentConfiguredSandbox
-      : sandbox;
-  if (sandbox === '1' || sandbox === 'true') sandbox = true;
-  else if (sandbox === '0' || sandbox === 'false' || !sandbox) sandbox = false;
-
-  if (sandbox === false) {
-    return '';
-  }
-
-  if (typeof sandbox === 'string' && sandbox) {
-    if (!isSandboxCommand(sandbox)) {
-      console.error(
-        `ERROR: invalid sandbox command '${sandbox}'. Must be one of ${VALID_SANDBOX_COMMANDS.join(
-          ', ',
-        )}`,
-      );
-      process.exit(1);
-    }
-    // confirm that specified command exists
-    if (commandExists.sync(sandbox)) {
-      return sandbox;
-    }
-    console.error(
-      `ERROR: missing sandbox command '${sandbox}' (from GEMINI_SANDBOX)`,
-    );
-    process.exit(1);
-  }
-
-  // look for seatbelt, docker, or podman, in that order
-  // for container-based sandboxing, require sandbox to be enabled explicitly
-  if (os.platform() === 'darwin' && commandExists.sync('sandbox-exec')) {
-    return 'sandbox-exec';
-  } else if (commandExists.sync('docker') && sandbox === true) {
-    return 'docker';
-  } else if (commandExists.sync('podman') && sandbox === true) {
-    return 'podman';
-  }
-
-  // throw an error if user requested sandbox but no command was found
-  if (sandbox === true) {
-    console.error(
-      'ERROR: GEMINI_SANDBOX is true but failed to determine command for sandbox; ' +
-        'install docker or podman or specify command in GEMINI_SANDBOX',
-    );
-    process.exit(1);
-  }
-
-  return '';
-}
-
 export async function loadSandboxConfig(
   settings: Settings,
-  argv: SandboxCliArgs,
+  argv: { sandbox?: boolean | string; 'sandbox-image'?: string },
 ): Promise<SandboxConfig | undefined> {
   const sandboxOption = argv.sandbox ?? settings.sandbox;
-  const command = getSandboxCommand(sandboxOption);
+  if (!sandboxOption) {
+    return undefined;
+  }
+  const scriptPath = path.resolve(process.cwd(), 'scripts', 'sandbox_command.js');
+  // Invoke shared sandbox_command script to determine sandbox command
+  let command = '' as SandboxConfig['command'];
+  try {
+    const raw = execSync(`node ${scriptPath} -q`, { encoding: 'utf-8' }).trim();
+    // raw should be one of the valid commands: 'docker', 'podman', or 'sandbox-exec'
+    command = raw as SandboxConfig['command'];
+  } catch {
+    return undefined;
+  }
 
   const packageJson = await getPackageJson();
   const image =


### PR DESCRIPTION
<p dir="auto" style="box-sizing: border-box; margin-top: 0px !important; margin-bottom: 16px; color: rgb(240, 246, 252); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(13, 17, 23); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Previously<span> </span><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; padding: 0.2em 0.4em; margin: 0px; white-space: break-spaces; background-color: rgba(101, 108, 118, 0.2); border-radius: 6px;">sandboxConfig.ts</code><span> </span>re-implemented the logic for picking ‘docker’/‘podman’/‘sandbox-exec’, duplicating the code in<span> </span><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; padding: 0.2em 0.4em; margin: 0px; white-space: break-spaces; background-color: rgba(101, 108, 118, 0.2); border-radius: 6px;">scripts/sandbox_command.js</code><span> </span>and making it brittle. Now we shell out to the canonical JS script, removing the duplication and keeping all sandbox logic in one place.</p><p dir="auto" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 16px; color: rgb(240, 246, 252); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(13, 17, 23); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><span class="issue-keyword tooltipped tooltipped-se" aria-label="This pull request closes issue #940." style="box-sizing: border-box; position: relative; border-bottom: 1px dotted rgb(61, 68, 77);">Closes</span><span> </span><a class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3137358782" data-permission-text="Title is private" data-url="https://github.com/google-gemini/gemini-cli/issues/940" data-hovercard-type="issue" data-hovercard-url="/google-gemini/gemini-cli/issues/940/hovercard" href="https://github.com/google-gemini/gemini-cli/issues/940" aria-keyshortcuts="Alt+ArrowUp" style="box-sizing: border-box; background-color: transparent; color: rgb(68, 147, 248); text-decoration: underline; white-space: normal; text-underline-offset: 0.2rem;">#940</a>.</p><h2 dir="auto" style="box-sizing: border-box; margin-top: 24px; margin-bottom: 16px; font-size: 1.5em; font-weight: 600; line-height: 1.25; padding-bottom: 0.3em; border-bottom: 1px solid rgba(61, 68, 77, 0.7); color: rgb(240, 246, 252); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(13, 17, 23); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">TLDR</h2><p dir="auto" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 16px; color: rgb(240, 246, 252); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(13, 17, 23); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Instead of re-implementing “docker/podman/sandbox-exec” detection in sandboxConfig.ts, we now shell out to the single source of truth at [sandbox_command.js]. This removes brittle duplication and keeps all sandbox machinery in one place.</p><p dir="auto" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 16px; color: rgb(240, 246, 252); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(13, 17, 23); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Thank you for tagging this as a newcomer. This is my first commit, and more than happy to contribute.</p><h2 dir="auto" style="box-sizing: border-box; margin-top: 24px; margin-bottom: 16px; font-size: 1.5em; font-weight: 600; line-height: 1.25; padding-bottom: 0.3em; border-bottom: 1px solid rgba(61, 68, 77, 0.7); color: rgb(240, 246, 252); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(13, 17, 23); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Dive Deeper</h2><p dir="auto" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 16px; color: rgb(240, 246, 252); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(13, 17, 23); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Previously, the TS config loader duplicated the logic for picking a container engine or Seatbelt. Any divergence between that code and the JS script caused build inconsistencies or required unnecessary rebuilds. By invoking node [sandbox_command.js]-q directly, we centralize detection and honor any future platform patches in one file.</p><h2 dir="auto" style="box-sizing: border-box; margin-top: 24px; margin-bottom: 16px; font-size: 1.5em; font-weight: 600; line-height: 1.25; padding-bottom: 0.3em; border-bottom: 1px solid rgba(61, 68, 77, 0.7); color: rgb(240, 246, 252); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(13, 17, 23); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Reviewer Test Plan</h2><ol dir="auto" style="box-sizing: border-box; padding: 0px; margin-top: 0px; margin-bottom: 16px; position: relative; color: rgb(240, 246, 252); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(13, 17, 23); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li style="box-sizing: border-box; margin-left: 24px;">Run npm run build and npm test to ensure CI passes.</li><li style="box-sizing: border-box; margin-top: 0.25em; margin-left: 24px;">Try enabling sandbox via:</li></ol><ul dir="auto" style="box-sizing: border-box; padding: 0px; margin-top: 0px; margin-bottom: 16px; position: relative; color: rgb(240, 246, 252); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(13, 17, 23); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li style="box-sizing: border-box; margin-left: 24px;">[GEMINI_SANDBOX=1 gemini ]</li><li style="box-sizing: border-box; margin-top: 0.25em; margin-left: 24px;">--sandbox docker</li><li style="box-sizing: border-box; margin-top: 0.25em; margin-left: 24px;">--sandbox-exec on macOS (verify Seatbelt profile applies)</li></ul><ol start="3" dir="auto" style="box-sizing: border-box; padding: 0px; margin-top: 0px; margin-bottom: 16px; position: relative; color: rgb(240, 246, 252); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(13, 17, 23); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li style="box-sizing: border-box; margin-left: 24px;">Confirm the selected engine matches the output of node [sandbox_command.js] -q.</li></ol><h2 dir="auto" style="box-sizing: border-box; margin-top: 24px; margin-bottom: 16px; font-size: 1.5em; font-weight: 600; line-height: 1.25; padding-bottom: 0.3em; border-bottom: 1px solid rgba(61, 68, 77, 0.7); color: rgb(240, 246, 252); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(13, 17, 23); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Testing Matrix</h2><markdown-accessiblity-table data-catalyst="" style="box-sizing: border-box; display: block; color: rgb(240, 246, 252); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(13, 17, 23); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">
  | 🍏 | 🪟 | 🐧
-- | -- | -- | --
npm run | ✅ | ✅ | ✅
npx | ✅ | ✅ | ✅
Docker | ✅ | ✅ | ✅
Podman | - | ✅ | ✅
Seatbelt | ✅ | - | -

</markdown-accessiblity-table><h2 dir="auto" style="box-sizing: border-box; margin-top: 24px; margin-bottom: 16px; font-size: 1.5em; font-weight: 600; line-height: 1.25; padding-bottom: 0.3em; border-bottom: 1px solid rgba(61, 68, 77, 0.7); color: rgb(240, 246, 252); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(13, 17, 23); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Linked issues / bugs</h2><p dir="auto" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 0px !important; color: rgb(240, 246, 252); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(13, 17, 23); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><a class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3137358782" data-permission-text="Title is private" data-url="https://github.com/google-gemini/gemini-cli/issues/940" data-hovercard-type="issue" data-hovercard-url="/google-gemini/gemini-cli/issues/940/hovercard" href="https://github.com/google-gemini/gemini-cli/issues/940" aria-keyshortcuts="Alt+ArrowUp" style="box-sizing: border-box; background-color: transparent; color: rgb(68, 147, 248); text-decoration: underline; white-space: normal; text-underline-offset: 0.2rem;">#940</a><span> </span>: Duplicate snadbox_command logic in sandboxConfig.ts and JS script.</p>Previously sandboxConfig.ts re-implemented the logic for picking ‘docker’/‘podman’/‘sandbox-exec’, duplicating the code in scripts/sandbox_command.js and making it brittle. Now we shell out to the canonical JS script, removing the duplication and keeping all sandbox logic in one place.

Closes https://github.com/google-gemini/gemini-cli/issues/940.

TLDR
Instead of re-implementing “docker/podman/sandbox-exec” detection in sandboxConfig.ts, we now shell out to the single source of truth at [sandbox_command.js]. This removes brittle duplication and keeps all sandbox machinery in one place.

Thank you for tagging this as a newcomer. This is my first commit, and more than happy to contribute.

Dive Deeper
Previously, the TS config loader duplicated the logic for picking a container engine or Seatbelt. Any divergence between that code and the JS script caused build inconsistencies or required unnecessary rebuilds. By invoking node [sandbox_command.js]-q directly, we centralize detection and honor any future platform patches in one file.

Reviewer Test Plan
Run npm run build and npm test to ensure CI passes.
Try enabling sandbox via:
[GEMINI_SANDBOX=1 gemini ]
--sandbox docker
--sandbox-exec on macOS (verify Seatbelt profile applies)
Confirm the selected engine matches the output of node [sandbox_command.js] -q.
Testing Matrix
🍏	🪟	🐧
npm run	✅	✅	✅
npx	✅	✅	✅
Docker	✅	✅	✅
Podman	-	✅	✅
Seatbelt	✅	-	-
Linked issues / bugs
https://github.com/google-gemini/gemini-cli/issues/940 : Duplicate snadbox_command logic in sandboxConfig.ts and JS script.